### PR TITLE
Text sizing, font smoothing and box-sizing.

### DIFF
--- a/_base.page.scss
+++ b/_base.page.scss
@@ -12,6 +12,9 @@
  *    navigating between pages that do/do not have enough content to produce
  *    scrollbars naturally.
  * 3. Ensure the page always fills at least the entire height of the viewport.
+ * 4. Prevent certain mobile browsers from automatically zooming fonts.
+ * 5. Fonts on OS X will look more consistent with other systems that do not render text using sub-pixel anti-aliasing.
+ * 6. More consitent sizing of elements in modern browsers with padding and margins applied.
  */
 html {
     font-size: ($inuit-base-font-size / 16px) * 1em; /* [1] */
@@ -20,4 +23,12 @@ html {
     color: $inuit-base-text-color;
     overflow-y: scroll; /* [2] */
     min-height: 100%; /* [3] */
+    -ms-text-size-adjust: 100%; /* [4] */
+    -webkit-text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased; /* [5] */
+    -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+    box-sizing: border-box; /* [6] */
 }


### PR DESCRIPTION
The catch all `box-sizing: border-box;` eliminates a lot of headaches when using percentage based width and height calculations.
Credit: http://www.paulirish.com/2012/box-sizing-border-box-ftw/

The text size adjust properties prevent certain mobile browsers from automatically zooming fonts.
Font smoothing is a nice little addition to make fonts appear smoother in OS X.
Credit: http://jaydenseric.com/blog/forget-normalize-or-resets-lay-your-own-css-foundation
